### PR TITLE
OAP-36, OAP-39: No get_text() in OapenItem, register adapters for DB objects in Python

### DIFF
--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -1,6 +1,6 @@
 name: OAPEN Engine
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:
@@ -23,5 +23,6 @@ jobs:
           pipenv run isort --profile black src/
           pipenv run black --check src/ --exclude="lib/*"
           pipenv run flake8 src/ --ignore="lib/*, W, E203, E266, E501, W503, F403, F401"
+          pipenv run pytest
         
       

--- a/.github/workflows/engine.yml
+++ b/.github/workflows/engine.yml
@@ -23,6 +23,5 @@ jobs:
           pipenv run isort --profile black src/
           pipenv run black --check src/ --exclude="lib/*"
           pipenv run flake8 src/ --ignore="lib/*, W, E203, E266, E501, W503, F403, F401"
-          pipenv run pytest
         
       

--- a/oapen-engine/Makefile
+++ b/oapen-engine/Makefile
@@ -13,6 +13,10 @@ seed_db:
 
 clean_db:
 	cd src && pipenv run python tasks/clean.py
+
+clean_and_seed:
+	$(MAKE) clean_db 
+	$(MAKE) seed_db
 	
 run:
 	cd src && pipenv run python main.py

--- a/oapen-engine/src/data/connection.py
+++ b/oapen-engine/src/data/connection.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 import psycopg2
 from data.config import config
+from psycopg2.extras import register_composite
 
 
 def get_connection():
@@ -20,15 +21,12 @@ def get_connection():
         db_version = cur.fetchone()
         print(db_version)
 
-        # TODO: Register adapters for suggestion and ngram types
-
         cur.close()
 
     except (Exception, psycopg2.DatabaseError) as error:
         print(error)
     finally:
         return conn
-    return conn
 
 
 def close_connection(conn):
@@ -38,3 +36,7 @@ def close_connection(conn):
 
 
 connection = get_connection()
+
+
+register_composite("oapen_suggestions.suggestion", connection, globally=True)
+register_composite("oapen_suggestions.ngram", connection, globally=True)

--- a/oapen-engine/src/data/oapen.py
+++ b/oapen-engine/src/data/oapen.py
@@ -48,7 +48,7 @@ def get_item(handle) -> OapenItem:
     res = get(endpoint=GET_ITEM.format(handle=handle))
 
     if res is not None and len(res) > 0:
-        return transform_item_data(res[0])
+        return transform_item_data(res[0], get_bitstream_text(res[0]["bitstreams"]))
     return res
 
 
@@ -76,7 +76,7 @@ def get_collection_items_by_label(label, limit=None) -> List[OapenItem]:
     return res
 
 
-def get_bitstream_text(bitstreams, limit=None):
+def get_bitstream_text(bitstreams, limit=None) -> str:
     for bitstream in bitstreams:
         if bitstream["mimeType"] == "text/plain":
             retrieveLink = bitstream["retrieveLink"]

--- a/oapen-engine/src/data/oapen_db.py
+++ b/oapen-engine/src/data/oapen_db.py
@@ -1,8 +1,8 @@
-from typing import List
+from typing import List, Tuple
 
 import psycopg2
 from data.connection import connection
-from model.oapen_types import OapenNgram
+from model.oapen_types import OapenNgram, OapenSuggestion
 
 
 def mogrify_ngrams(ngrams) -> str:
@@ -116,22 +116,48 @@ def add_many_ngrams(ngrams) -> None:
 
 
 def get_all_ngrams() -> List[OapenNgram]:
+
     cursor = connection.cursor()
     query = """
-            SELECT * FROM oapen_suggestions.ngrams
+            SELECT handle, CAST (ngrams AS oapen_suggestions.ngram[]) FROM oapen_suggestions.ngrams
             """
 
     try:
 
         ngrams: List[OapenNgram] = []
+
         cursor.execute(query)
         records = cursor.fetchall()
 
-        for i in range(len(records[0])):
-            print(type(records[0][i]))
-            print(records[0][i])
+        for record in records:
+            ngrams.append((record[0], record[1]))
 
         return ngrams
+
+    except (Exception, psycopg2.Error) as error:
+        print(error)
+    finally:
+        cursor.close()
+
+
+def get_all_suggestions() -> List[Tuple[str, str, List[OapenSuggestion]]]:
+
+    cursor = connection.cursor()
+    query = """
+            SELECT handle, name, CAST (suggestions AS oapen_suggestions.suggestion[]) FROM oapen_suggestions.suggestions
+            """
+
+    try:
+
+        suggestions: List[OapenSuggestion] = []
+
+        cursor.execute(query)
+        records = cursor.fetchall()
+
+        for record in records:
+            suggestions.append((record[0], record[1], record[2]))
+
+        return suggestions
 
     except (Exception, psycopg2.Error) as error:
         print(error)

--- a/oapen-engine/src/data/oapen_db.py
+++ b/oapen-engine/src/data/oapen_db.py
@@ -127,10 +127,9 @@ def get_all_ngrams() -> List[OapenNgram]:
         cursor.execute(query)
         records = cursor.fetchall()
 
-        for i in range(1):
-            # print(records[i])
-            print(type(records[i][0]))
-            print(type(records[i][1]))
+        for i in range(len(records[0])):
+            print(type(records[0][i]))
+            print(records[0][i])
 
         return ngrams
 

--- a/oapen-engine/src/main.py
+++ b/oapen-engine/src/main.py
@@ -41,7 +41,7 @@ def run_demo():
 
         items.append(item)
 
-        text = Model.process_text(item.get_text())
+        text = Model.process_text(item.text)
         print(f"  {name}: text array\n{text[:30]}...\n")
 
         ngram_dict[handle] = Model.generate_ngram(text, 3)

--- a/oapen-engine/src/main.py
+++ b/oapen-engine/src/main.py
@@ -30,7 +30,7 @@ def test_functions():
     print(Model.get_n_most_occuring(sample_ngram_list, 2))
 
 
-def run_demo():
+def run_demo(show_results=True):
     items = []
     ngram_dict = {}
 
@@ -51,30 +51,31 @@ def run_demo():
 
         print("---------------------------------")
 
-    for name, handle in demo_books.items():
-        print(f"Showing similarity scores for all books relative to {name}:\n")
-        for name2, handle2 in demo_books.items():
-            # if handle == handle2:  # dont check self
-            #     continue
+    if show_results:
+        for name, handle in demo_books.items():
+            print(f"Showing similarity scores for all books relative to {name}:\n")
+            for name2, handle2 in demo_books.items():
+                # if handle == handle2:  # dont check self
+                #     continue
 
-            simple_similarity_score = 100 * Model.get_similarity_score(
-                ngram_dict[handle], ngram_dict[handle2], n=10000
-            )
-            print(
-                f"  Similarity score by simple count for title {name2}: {simple_similarity_score}%"
-            )
+                simple_similarity_score = 100 * Model.get_similarity_score(
+                    ngram_dict[handle], ngram_dict[handle2], n=10000
+                )
+                print(
+                    f"  Similarity score by simple count for title {name2}: {simple_similarity_score}%"
+                )
 
-            dict_similarity_score = 100 * Model.get_similarity_score_by_dict_count(
-                ngram_dict[handle], ngram_dict[handle2]
-            )
-            print(
-                f"  Similarity score by dict count for title {name2}: {dict_similarity_score}%"
-            )
-            print()
+                dict_similarity_score = 100 * Model.get_similarity_score_by_dict_count(
+                    ngram_dict[handle], ngram_dict[handle2]
+                )
+                print(
+                    f"  Similarity score by dict count for title {name2}: {dict_similarity_score}%"
+                )
+                print()
 
 
-def run_caching_test():
-
+def cache_demo():
+    print("Caching ngrams...")
     items = []
 
     for name, handle in demo_books.items():
@@ -82,17 +83,32 @@ def run_caching_test():
         items.append(item)
 
     Model.cache_ngrams_from_items(items)
+    print("Done caching ngrams.")
+
+
+def query_db_demo():
+    suggestions = OapenDB.get_all_suggestions()
+    ngrams = OapenDB.get_all_ngrams()
+
+    print("Querying suggestions...")
+    for i in range(min(5, len(suggestions))):
+        print(suggestions[i])
+
+    print("Querying ngrams...")
+    for i in range(min(5, len(ngrams))):
+        print(ngrams[i][0], ngrams[i][1][0:4])
 
 
 def run_ngrams():
-    # run_demo()
-    run_caching_test()
+    run_demo()
+    cache_demo()
 
 
 def main():
-    run_ngrams()
+    run_demo(show_results=False)
+    cache_demo()
+    query_db_demo()
 
-    OapenDB.get_all_ngrams()
     close_connection(connection)
     return
 

--- a/oapen-engine/src/model/ngrams.py
+++ b/oapen-engine/src/model/ngrams.py
@@ -11,6 +11,7 @@ from nltk.corpus import stopwords  # pylint: disable=import-error
 from .oapen_types import (  # pylint: disable=relative-beyond-top-level
     NgramDict,
     OapenItem,
+    OapenNgram,
 )
 
 nltk.download("stopwords")
@@ -103,16 +104,23 @@ def get_similarity_score_by_dict_count(ngrams1: NgramDict, ngrams2: NgramDict) -
     return repeated / total
 
 
+def get_ngrams_for_items(items: List[OapenItem], n=3) -> List[OapenNgram]:
+    rows = []
+    for item in items:
+        text = process_text(item.text)
+        ngrams = generate_ngram(text, n)
+        rows.append((item.handle, list(sort_ngrams_by_count(ngrams))))
+    return rows
+
+
 # @params: handle = handle of item; ngrams = {str : int}
 def cache_ngrams(handle: str, ngrams: NgramDict):
     OapenDB.add_single_ngrams((handle, list(sort_ngrams_by_count(ngrams))))
 
 
 def cache_ngrams_from_items(items: List[OapenItem], n=3):
-    rows = []
-    for item in items:
-        text = process_text(item.text)
-        ngrams = generate_ngram(text, n)
-        rows.append((item.handle, list(sort_ngrams_by_count(ngrams))))
+    rows = get_ngrams_for_items(items)
 
     OapenDB.add_many_ngrams(rows)
+
+    return rows

--- a/oapen-engine/src/model/ngrams.py
+++ b/oapen-engine/src/model/ngrams.py
@@ -40,7 +40,7 @@ def make_df(data: List[OapenItem]):
     df = pd.DataFrame(columns=["handle", "name", "text"])
 
     for item in data:
-        text = process_text(item.get_text())
+        text = process_text(item.text)
         df.loc[len(df.index)] = [item.handle, item.name, text]
     return df
 
@@ -111,7 +111,7 @@ def cache_ngrams(handle: str, ngrams: NgramDict):
 def cache_ngrams_from_items(items: List[OapenItem], n=3):
     rows = []
     for item in items:
-        text = process_text(item.get_text())
+        text = process_text(item.text)
         ngrams = generate_ngram(text, n)
         rows.append((item.handle, list(sort_ngrams_by_count(ngrams))))
 

--- a/oapen-engine/src/model/oapen_types.py
+++ b/oapen-engine/src/model/oapen_types.py
@@ -18,6 +18,8 @@ class OapenItem:
 OapenSuggestion = NewType("OapenSuggestion", Tuple[str, float])
 OapenNgram = NewType("OapenNgram", Tuple[str, List[Tuple[str, int]]])
 
+SuggestionRow = NewType("SuggestionRow", Tuple[str, str, List[OapenSuggestion]])
+
 NgramDict = Dict[str, int]
 
 

--- a/oapen-engine/src/model/oapen_types.py
+++ b/oapen-engine/src/model/oapen_types.py
@@ -1,10 +1,10 @@
-from typing import Dict, List, Tuple
-
-import data.oapen as OapenAPI
+from typing import Dict, List, NewType, Tuple
 
 
 class OapenItem:
-    def __init__(self, uuid, name, handle, expand, link, metadata, bitstreams):
+    def __init__(
+        self, uuid, name, handle, expand, link, metadata, bitstreams, text: str
+    ):
         self.uuid = uuid
         self.name = name
         self.handle = handle
@@ -12,28 +12,27 @@ class OapenItem:
         self.link = link
         self.metadata = metadata
         self.bitstreams = bitstreams
-
-    def get_text(self):
-        return OapenAPI.get_bitstream_text(self.bitstreams)
+        self.text = text
 
 
-OapenSuggestion = Tuple[str, float]
-OapenNgram = Tuple[str, List[Tuple[str, int]]]
+OapenSuggestion = NewType("OapenSuggestion", Tuple[str, float])
+OapenNgram = NewType("OapenNgram", Tuple[str, List[Tuple[str, int]]])
 
 NgramDict = Dict[str, int]
 
 
-def transform_item_data(item) -> OapenItem:
-    uuid = item["uuid"]
-    name = item["name"]
-    handle = item["handle"]
-    expand = item["expand"]
-    link = item["link"]
-    metadata = item["metadata"]
-    bitstreams = item["bitstreams"]
+def transform_item_data(item, text) -> OapenItem:
+    return OapenItem(
+        item["uuid"],
+        item["name"],
+        item["handle"],
+        item["expand"],
+        item["link"],
+        item["metadata"],
+        item["bitstreams"],
+        text,
+    )
 
-    return OapenItem(uuid, name, handle, expand, link, metadata, bitstreams)
 
-
-def transform_multiple_items_data(data: List[object]) -> List[OapenItem]:
-    return [transform_item_data(x) for x in data]
+def transform_multiple_items_data(items) -> List[OapenItem]:
+    return [transform_item_data(item, item["bitstreams"]) for item in items]

--- a/oapen-engine/src/tasks/seed.py
+++ b/oapen-engine/src/tasks/seed.py
@@ -13,7 +13,9 @@ def mock_suggestion_rows(n=10):
 
     rows = []
     for i in range(min(30, len(items))):
-        rows.append((items[i].handle, items[i].name, [(items[i].handle, i)]))
+        rows.append(
+            (items[i].handle, items[i].name, [(items[i].handle, j) for j in range(3)])
+        )
 
     return rows
 

--- a/oapen-engine/src/tasks/seed.py
+++ b/oapen-engine/src/tasks/seed.py
@@ -12,7 +12,7 @@ def mock_suggestion_rows(n=10):
     )
 
     rows = []
-    for i in range(min(30, len(items))):
+    for i in range(min(n, len(items))):
         rows.append(
             (items[i].handle, items[i].name, [(items[i].handle, j) for j in range(3)])
         )


### PR DESCRIPTION
Two tickets in one because OAP-36 helps OAP-39 get done.

Closes OAP-36. Previously, we had a method called `get_text()` in `OapenItem` that would make a call to the API to retrieve an item's text from its bitstreams. This caused a circular dependency between our model and data ingest. Instead, we retrieve text in the same call as the initial retrieval of the item from the API in order to populate the entire OapenItem in one go. This makes an assumption that a bitstream will always be available. If this is not the case, the text will be the empty string.

Closes OAP-39. We can now query all suggestions and ngrams from the database. The ngram[] and suggestion[] are adapted into Python tuples as defined in `model/oapen_types.py`. We should consider some pairing to clean up now that data types are working.

![Screen Shot 2022-11-04 at 20 11 15](https://user-images.githubusercontent.com/16270964/200091665-3efb0cd7-5493-4dd1-abd5-287e675cb929.png)
