### PR TITLE
Export Docker port to edge

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,13 @@ services:
     expose:
        - 3001
     ports:
-        - "127.0.0.1:3001:3001"
+        - "0.0.0.0:3001:3001"
   web:
     build: ./web/
     expose:
         - 3000
     ports:
-        - "127.0.0.1:3000:3000"
+        - "0.0.0.0:3000:3000"
 volumes:
   db:
     driver: local


### PR DESCRIPTION
The current setup only allows localhost (`127.0.0.1`) to access the open port, this should be all (`0.0.0.0`)