### PR TITLE
OAP-54: Full harvest for DB, add threshold

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -35,6 +35,12 @@ npm start
 
   - e.g. http://localhost:3001/api/20.400.12657/47581
 
+- `Endpoint: /GET http://localhost:3001/api/{handle}/?threshold={integer}`
+
+  - e.g. http://localhost:3001/api/20.400.12657/47581/?threshold=5
+
 - `Endpoint: /GET http://localhost:3001/api/{handle}/ngrams`
 
   - e.g. http://localhost:3001/api/20.400.12657/47581/ngrams
+
+

--- a/api/db/data.js
+++ b/api/db/data.js
@@ -2,18 +2,33 @@ const validate = require("../validate.js");
 const { ParameterizedQuery: PQ } = require("pg-promise");
 
 const db = require("./connection.js");
+const { result } = require("./connection.js");
 
-async function querySuggestions(handle) {
+async function querySuggestions(handle, threshold = 0) {
   await validate.checkHandle(handle);
 
   const query = new PQ({
-    text: "SELECT * FROM oapen_suggestions.suggestions WHERE handle = $1",
-    values: [handle],
+    text: `SELECT s.*
+    FROM (SELECT handle, unnest(suggestions::oapen_suggestions.suggestion[]) AS suggestion 
+    FROM oapen_suggestions.suggestions) s
+    WHERE handle = $1
+    AND (s.suggestion).similarity >= $2`,
+    values: [handle, threshold],
   });
 
-  return db.one(query).catch((error) => {
+  let result = await db.many(query).catch((error) => {
     return { error: { name: error.name, message: error.message } };
   });
+
+  if (result?.["error"])
+    return result;
+  
+  const data = {
+    "handle": handle,
+    "suggestions": result.map((e) => {return e["suggestion"];})
+  };
+  
+  return data;
 }
 
 async function queryNgrams(handle) {

--- a/api/routes.js
+++ b/api/routes.js
@@ -8,9 +8,11 @@ const data = require("./db/data.js");
 router.get("/:handle([0-9]+.[0-9]+.[0-9]+/[0-9]+)", async (req, res) => {
   try {
     let handle = req.params.handle;
+    let threshold = parseInt(req.query.threshold) || 0;
+
     await validate.checkHandle(handle);
 
-    let responseData = await data.querySuggestions(handle);
+    let responseData = await data.querySuggestions(handle, threshold);
 
     if (
       responseData?.["error"] &&
@@ -24,6 +26,7 @@ router.get("/:handle([0-9]+.[0-9]+.[0-9]+/[0-9]+)", async (req, res) => {
     res.status(200).json({
       items: responseData,
     });
+
   } catch (e) {
     console.error(e);
     return res.status(500).json({ error: "Internal server error" });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ version: "3.8"
 services:
   oapen-engine :
     build: ./oapen-engine/
+    environment:
+      - RUN_CLEAN=0
+      - COLLECTION_IMPORT_LIMIT=0 # Set to 0 for full harvest
+      - REFRESH_PERIOD=300
   api:
     build: ./api/
     expose:

--- a/oapen-engine/src/data/oapen.py
+++ b/oapen-engine/src/data/oapen.py
@@ -32,15 +32,21 @@ def transform_multiple_items_data(items) -> List[OapenItem]:
     ]
 
 
-def get(endpoint, params=None):
-    res = requests.get(url=SERVER_PATH + endpoint, params=params)
-    if res.ok:
+def get(endpoint, params=None, log=False):
+    res = requests.get(url=SERVER_PATH + endpoint, params=params, timeout=(None, 120))
+
+    ret = None
+    if res.status_code == 200:
         if res.headers.get("content-type") == "application/json":
-            return res.json()
-        return res.content
+            ret = res.json()
+        else:
+            ret = res.content
     else:
-        print(res.url + ": " + str(res.status_code))
-        return None
+        print("GET {}: {}".format(res.url, res.status_code))
+
+    if log:
+        print("GET {}: {}".format(res.url, res.status_code))
+    return ret
 
 
 def get_all_communities():
@@ -69,7 +75,7 @@ def get_collections_from_community(id):
 
 
 def get_all_collections():
-    res = get(endpoint=GET_COLLECTIONS)
+    res = get(endpoint=GET_COLLECTIONS, log=True)
     return res
 
 
@@ -77,6 +83,7 @@ def get_collection_items_by_id(id, limit=None, offset=None) -> List[OapenItem]:
     res = get(
         endpoint=GET_COLLECTION_ITEMS.format(id=id),
         params={"expand": "bitstreams,metadata", "limit": limit, "offset": offset},
+        log=True,
     )
 
     if res is not None and len(res) > 0:
@@ -87,7 +94,9 @@ def get_collection_items_by_id(id, limit=None, offset=None) -> List[OapenItem]:
 def get_collection_items_by_label(label, limit=None) -> List[OapenItem]:
     label = "+".join(label.split(" "))
     res = get(
-        endpoint=GET_COLLECTION_BY_LABEL.format(label=label), params={"limit": limit}
+        endpoint=GET_COLLECTION_BY_LABEL.format(label=label),
+        params={"limit": limit},
+        log=True,
     )
 
     if res is not None and len(res) > 0:

--- a/oapen-engine/src/tasks/config.py
+++ b/oapen-engine/src/tasks/config.py
@@ -1,27 +1,27 @@
 # Limit of how many items per collection to import from OAPEN in seed.py
-COLLECTION_IMPORT_LIMIT = 10
+COLLECTION_IMPORT_LIMIT = None
 
-ITEMS_PER_IMPORT_THREAD = 25
+ITEMS_PER_IMPORT_THREAD = 50
 
 # Max thread count for data ingest
-IO_MAX_WORKERS = 10
+IO_MAX_WORKERS = 5
 
 # Size of list of items to process into ngrams per process
-NGRAMS_PER_PROCESS = 25
-NGRAMS_PER_INSERT = 100
+NGRAMS_PER_INSERT = 500
 
-
-# Number of ngrams that two items need to share in order to be similar
-SCORE_THRESHOLD = 5
+# Minimum number of ngrams that two items need to share in order to be similar
+SCORE_THRESHOLD = 1
 
 # How many ngrams to use in item similarity comparision
 TOP_K_NGRAMS_COUNT = 30
 
 # Number of threads to generate suggestions
-SUGGESTIONS_MAX_WORKERS = 100
-SUGGESTIONS_MAX_ITEMS = 10
-
+SUGGESTIONS_MAX_WORKERS = 250
+SUGGESTIONS_MAX_ITEMS = 25
 
 # Update items that were modifed since X days ago
 UPDATE_DAYS_BEFORE = 30
 REFRESH_IMPORT_LIMIT = 50
+
+# Seconds between each item refresh period
+REFRESH_PERIOD = 300

--- a/oapen-engine/src/tasks/config.py
+++ b/oapen-engine/src/tasks/config.py
@@ -1,6 +1,3 @@
-# Limit of how many items per collection to import from OAPEN in seed.py
-COLLECTION_IMPORT_LIMIT = None
-
 ITEMS_PER_IMPORT_THREAD = 50
 
 # Max thread count for data ingest
@@ -22,6 +19,3 @@ SUGGESTIONS_MAX_ITEMS = 25
 # Update items that were modifed since X days ago
 UPDATE_DAYS_BEFORE = 30
 REFRESH_IMPORT_LIMIT = 50
-
-# Seconds between each item refresh period
-REFRESH_PERIOD = 300

--- a/oapen-engine/src/tasks/daemon.py
+++ b/oapen-engine/src/tasks/daemon.py
@@ -1,9 +1,9 @@
 # Daemon to run processes in the background
+import os
 import signal
 import sys
 import time
 
-import config
 from clean import run as run_clean
 from data.connection import get_connection
 from data.oapen_db import OapenDB
@@ -19,13 +19,14 @@ def signal_handler(signal, frame):
 
 signal.signal(signal.SIGINT, signal_handler)
 
-
 print("Daemon up and running")
 
 conn = get_connection()
 db = OapenDB(conn)
 
-if not db.table_exists("suggestions") or not db.table_exists("ngrams"):
+if int(os.environ["RUN_CLEAN"]) == 1 or (
+    not db.table_exists("suggestions") or not db.table_exists("ngrams")
+):
     print("STARTED: clean.py")
     run_clean()
     print("STOPPED: clean.py")
@@ -42,7 +43,7 @@ acc = 0
 while True:
     print("Daemon still running")
 
-    if acc >= config.REFRESH_PERIOD:
+    if acc >= int(os.environ["REFRESH_PERIOD"]):
         print("STARTED: refresh items")
         run_refresh_items()
         print("STOPPED: refresh items")

--- a/oapen-engine/src/tasks/daemon.py
+++ b/oapen-engine/src/tasks/daemon.py
@@ -3,7 +3,10 @@ import signal
 import sys
 import time
 
+import config
 from clean import run as run_clean
+from data.connection import get_connection
+from data.oapen_db import OapenDB
 from generate_suggestions import run as run_generate_suggestions
 from refresh_items import run as run_refresh_items
 from seed import run as run_seed
@@ -18,9 +21,17 @@ signal.signal(signal.SIGINT, signal_handler)
 
 
 print("Daemon up and running")
-print("STARTED: clean.py")
-run_clean()
-print("STOPPED: clean.py")
+
+conn = get_connection()
+db = OapenDB(conn)
+
+if not db.table_exists("suggestions") or not db.table_exists("ngrams"):
+    print("STARTED: clean.py")
+    run_clean()
+    print("STOPPED: clean.py")
+
+conn.close()
+
 print("STARTED: seed.py")
 run_seed()
 print("STOPPED: seed.py")
@@ -31,7 +42,7 @@ acc = 0
 while True:
     print("Daemon still running")
 
-    if acc >= 300:
+    if acc >= config.REFRESH_PERIOD:
         print("STARTED: refresh items")
         run_refresh_items()
         print("STOPPED: refresh items")

--- a/oapen-engine/src/tasks/seed.py
+++ b/oapen-engine/src/tasks/seed.py
@@ -170,16 +170,17 @@ def run():
     db_futures.append(db_pool.submit(db_task, db, db_queue, db_event))
 
     #
-    #  Data import: Get config.COLLECTION_IMPORT_LIMIT items from all collections in the OAPEN catalog
+    #  Data import: COLLECTION_IMPORT_LIMIT items from all collections in the OAPEN catalog
     #
 
     url_params = []
+    COLLECTION_IMPORT_LIMIT = int(os.environ["COLLECTION_IMPORT_LIMIT"])
 
     for collection in collections:
         num_items = (
             collection["numberItems"]
-            if config.COLLECTION_IMPORT_LIMIT is None
-            else min(config.COLLECTION_IMPORT_LIMIT, collection["numberItems"])
+            if COLLECTION_IMPORT_LIMIT == 0
+            else min(COLLECTION_IMPORT_LIMIT, collection["numberItems"])
         )
 
         total_items += num_items


### PR DESCRIPTION
- Updated seed script to harvest full OAPEN catalog
- Use only one thread for continuous batch DB population
- Move some parameters for seed script to `docker-compose.yml`
- Add threshold parameter to api as shown below

`GET http://localhost:3001/api/20.500.12657/22309/`
```
{"items":{"handle":"20.500.12657/22309","suggestions":["(20.500.12657/22466,4)","(20.500.12657/22468,3)","(20.500.12657/22333,2)","(20.500.12657/22465,2)","(20.500.12657/41387,2)","(20.500.12657/39373,1)","(20.500.12657/45831,1)","(20.500.12657/36961,1)","(20.500.12657/51327,1)"]}}
```

`GET http://localhost:3001/api/20.500.12657/22309/?threshold=3`
```
{"items":{"handle":"20.500.12657/22309","suggestions":["(20.500.12657/22466,4)","(20.500.12657/22468,3)"]}}
```