### PR TITLE
Filter multi-line stopwords

### DIFF
--- a/oapen-engine/src/model/ngrams.py
+++ b/oapen-engine/src/model/ngrams.py
@@ -1,27 +1,26 @@
+import re
 import string
 from typing import List
 
-import nltk 
-from nltk import word_tokenize 
+import nltk
+import pandas as pd
+from nltk import word_tokenize
+
 from .stopwords_processor import STOPWORDS
-import pandas as pd  
 
-nltk.download('punkt')
+nltk.download("punkt")
 
-from .oapen_types import (
-    NgramDict,
-    NgramRowWithoutDate,
-    OapenItem,
-)
+from .oapen_types import NgramDict, NgramRowWithoutDate, OapenItem
+
 
 def process_text(text):
-    l_text = text.lower()
-    p_text = "".join([c for c in l_text if c not in string.punctuation])
+    p_text = "".join([c for c in text.lower() if c not in string.punctuation])
+    stopwords_regex = re.compile(r"\b%s\b" % r"\b|\b".join(map(re.escape, STOPWORDS)))
+    p_text = stopwords_regex.sub("", p_text)
     words = word_tokenize(p_text)
     filtered_words = list(
-        filter(lambda x: x not in STOPWORDS and x.isalpha(), words)
+        filter(lambda x: x.isalpha(), words)
     )  # added isalpha to check that it contains only letters
-
     return filtered_words
 
 

--- a/oapen-engine/src/test/data/test_ngrams.py
+++ b/oapen-engine/src/test/data/test_ngrams.py
@@ -2,9 +2,11 @@ import model.ngrams as ngrams
 
 test_text1 = "Foxes are cunning animals. There was a quick, red fox known to avoid crossing roads during the day, doing so only at night."
 test_text2 = "The quick red fox jumped over the lazy brown dog. It had a fantastic time doing so, as it felt finally free. The fox had been in the zoo for far too long, held in captivity."
+test_text3 = "amsterdam amsterdam university publisher school tree dog"
 
 processed_text1 = ['foxes', 'cunning', 'animals', 'quick', 'red', 'fox', 'known', 'avoid', 'crossing', 'roads', 'day', 'night']
 processed_text2 = ['quick', 'red', 'fox', 'jumped', 'lazy', 'brown', 'dog', 'fantastic', 'time', 'felt', 'finally', 'free', 'fox', 'zoo', 'far', 'long', 'held', 'captivity']
+processed_text3 = ['publisher', 'school', 'tree', 'dog']
 
 ngrams1 = {
     'foxes cunning animals': 1, 
@@ -40,6 +42,7 @@ ngrams2 = {
 def test_process_text():
     assert(ngrams.process_text(test_text1) == processed_text1)
     assert(ngrams.process_text(test_text2) == processed_text2)
+    assert(ngrams.process_text(test_text3) == processed_text3)
 
 def test_generate_ngram():
     assert(ngrams.generate_ngram(processed_text1) == ngrams1)


### PR DESCRIPTION
Uses regex to avoid matching on substrings (e.g. "catch" would not be filtered by stopword "cat")