### PR TITLE
Change database build & rebuild behavior, removes RUN_CLEAN option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,47 @@
 # OAPEN Suggestion Service
 
 ## Description
+
 The OAPEN Suggestion Service uses natural-language processing to suggest books based on their content similarities. To protect user privacy, we utilize text analysis rather than usage data to provide recommendations. This service is built on the proof-of-concept and paper by Ronald Snijder from the OAPEN Foundation, and you can [read the paper here](https://liberquarterly.eu/article/view/10938).
 
 ## Table of Contents
-  * [Installation (Server)](#installation-server)
-    + [DigitalOcean Droplet](#digitalocean-droplet)
-    + [DigitalOcean Managed Database](#digitalocean-managed-database)
-    + [Setup Users & Install Requirements](#setup-users--install-requirements)
-    + [Clone & Configure the Project](#clone--configure-the-project)
-    + [SSL Certificate](#ssl-certificate)
-  * [Running](#running)
-  * [Endpoints](#endpoints)
-  * [Service Components](#service-components)
-    + [Suggestion Engine](#suggestion-engine)
-    + [API](#api)
-    + [Embed Script](#embed-script)
-    + [Web Demo](#web-demo)
-  * [Updates](#updates)
-  * [Local Installation (No Server)](#local-installation-no-server)
+
+- [Installation (Server)](#installation-server)
+  - [DigitalOcean Droplet](#digitalocean-droplet)
+  - [DigitalOcean Managed Database](#digitalocean-managed-database)
+  - [Setup Users & Install Requirements](#setup-users--install-requirements)
+  - [Clone & Configure the Project](#clone--configure-the-project)
+  - [SSL Certificate](#ssl-certificate)
+- [Running](#running)
+- [Endpoints](#endpoints)
+- [Service Components](#service-components)
+  - [Suggestion Engine](#suggestion-engine)
+  - [API](#api)
+  - [Embed Script](#embed-script)
+  - [Web Demo](#web-demo)
+- [Updates](#updates)
+- [Local Installation (No Server)](#local-installation-no-server)
 
 ## Installation (Server)
 
 ### DigitalOcean Droplet
+
 1. Log in to your DigitalOcean account.
 2. Create a new Droplet.
 3. Under "Choose an image" select "Marketplace" and search for "Docker". Select "Docker 20.10.21 on Ubuntu 22.04".
 4. Choose any size, but the cheapest option will work fine.
 5. If you do not have an ssh key, generate one with:
-    ```bash
-    ssh-keygen -t rsa -b 4096
-    ```
-    And copy the public key to your clipboard. If you have a key on your computer already, you can use that.
-7. Under "Choose Authentication Method" choose "SSH Key" and click "New SSH Key", and in the popup window paste the public key you copied to your clipboard. Make sure it is selected.
-8. Give the Droplet a name and click "Create".
-9. Open the firewall ports 
-    - https://cloud.digitalocean.com/networking/firewalls
+   ```bash
+   ssh-keygen -t rsa -b 4096
+   ```
+   And copy the public key to your clipboard. If you have a key on your computer already, you can use that.
+6. Under "Choose Authentication Method" choose "SSH Key" and click "New SSH Key", and in the popup window paste the public key you copied to your clipboard. Make sure it is selected.
+7. Give the Droplet a name and click "Create".
+8. Open the firewall ports
+   - https://cloud.digitalocean.com/networking/firewalls
 
 ### DigitalOcean Managed Database
+
 1. From the DigitalOcean dashboard, click "Databases" > "Create Database".
 2. Ideally, select the same region & datacenter as the Droplet you just created, so they can be part of the same VPC network.
 3. Choose "PostgreSQL v15".
@@ -48,9 +52,9 @@ The OAPEN Suggestion Service uses natural-language processing to suggest books b
 ### Setup Users & Install Requirements
 
 1. Log in to the droplet over SSH:
-    ```bash
-    ssh root@<your-droplet-ip>
-    ```
+   ```bash
+   ssh root@<your-droplet-ip>
+   ```
 2. Create a new user `oapen` and set a password, adding them to the `sudo` and `docker` groups, then login as the new user:
 
    ```bash
@@ -60,10 +64,11 @@ The OAPEN Suggestion Service uses natural-language processing to suggest books b
    ```
 
 3. Install the `docker compose` command:
-    ```bash
-    sudo apt-get update
-    sudo apt-get install docker-compose-plugin
-    ```
+
+   ```bash
+   sudo apt-get update
+   sudo apt-get install docker-compose-plugin
+   ```
 
 4. Change the SSH configuration file to disallow root login:
 
@@ -73,98 +78,109 @@ The OAPEN Suggestion Service uses natural-language processing to suggest books b
 
 5. Allow SSH login with non-root user with the same SSH keys you uploaded to DigitalOcean:
 
-    ```bash
-    mkdir -p ~/.ssh
-    sudo cp /root/.ssh/authorized_keys ~/.ssh/
-    sudo chown -R oapen:oapen ~/.ssh
-    sudo chmod 700 ~/.ssh
-    sudo chmod 600 ~/.ssh/authorized_keys
-    sudo systemctl restart ssh
-    ```
+   ```bash
+   mkdir -p ~/.ssh
+   sudo cp /root/.ssh/authorized_keys ~/.ssh/
+   sudo chown -R oapen:oapen ~/.ssh
+   sudo chmod 700 ~/.ssh
+   sudo chmod 600 ~/.ssh/authorized_keys
+   sudo systemctl restart ssh
+   ```
 
 6. Create a swapfile to avoid issues with high memory usage:
 
-    ```bash
-    sudo fallocate -l 1G /swapfile
-    sudo chmod 600 /swapfile
-    sudo mkswap /swapfile
-    sudo swapon /swapfile
-    echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
-    ```
+   ```bash
+   sudo fallocate -l 1G /swapfile
+   sudo chmod 600 /swapfile
+   sudo mkswap /swapfile
+   sudo swapon /swapfile
+   echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+   ```
 
-    > Feel free to replace `1G` in the first command with `4G`. Although the service should never use this much memory, extra swap never hurts if you have the disk space to spare. More on swap [here](https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-20-04).
+   > Feel free to replace `1G` in the first command with `4G`. Although the service should never use this much memory, extra swap never hurts if you have the disk space to spare. More on swap [here](https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-20-04).
 
 7. Restart the droplet to persist all of the changes. From now on, login to the droplet with:
 
-    ```bash
-    ssh oapen@<your-droplet-ip>
-    ```
+   ```bash
+   ssh oapen@<your-droplet-ip>
+   ```
 
 ### Clone & Configure the Project
 
 1. Clone the repository and cd into the directory it creates:
-    ```bash
-    git clone https://github.com/EbookFoundation/oapen-suggestion-service.git
-    cd oapen-suggestion-service
-    ```
-    > You can clone this anywhere but in the home directory is easiest.
+   ```bash
+   git clone https://github.com/EbookFoundation/oapen-suggestion-service.git
+   cd oapen-suggestion-service
+   ```
+   > You can clone this anywhere but in the home directory is easiest.
 2. Copy the `.env.template` file to `.env`:
-    ```bash
-    cp .env.template .env
-    ```
+
+   ```bash
+   cp .env.template .env
+   ```
 
 3. Using a text editor like `vim` or `nano` configure all of the options in `.env`:
-    ```properties
-    API_PORT=<Port to serve API on>
-    POSTGRES_HOST=<Hostname of postgres server>
-    POSTGRES_PORT=<Port postgres is running on>
-    POSTGRES_DB_NAME=<Name of the postgres database>
-    POSTGRES_USERNAME=<Username of the postgres user>
-    POSTGRES_PASSWORD=<Password of the postgres user>
-    POSTGRES_SSLMODE=<'require' when using a managed database>
-    ```
 
-    > Postgres credentials can be found in the "Connection details" section of the managed database
+   ```properties
+   API_PORT=<Port to serve API on>
+   POSTGRES_HOST=<Hostname of postgres server>
+   POSTGRES_PORT=<Port postgres is running on>
+   POSTGRES_DB_NAME=<Name of the postgres database>
+   POSTGRES_USERNAME=<Username of the postgres user>
+   POSTGRES_PASSWORD=<Password of the postgres user>
+   POSTGRES_SSLMODE=<'require' when using a managed database>
+   ```
 
-4. Open the `docker-compose.yml` file and find the line:
-    ```dockerfile
-    - RUN_CLEAN=1
-    ```
-    This is set to `1` by default, which causes the database to be ***COMPLETELY*** deleted and the types recreated each time the server restarts. It is important to have this set to `1` only on the _first run of the application_, or after making changes that affect the structure of the database. As soon as you run the application with the following command, you should change the line to:
-    ```dockerfile
-    - RUN_CLEAN=0
-    ```
-    To prevent this behavior.
+   > Postgres credentials can be found in the "Connection details" section of the managed database
 
 ### SSL Certificate
 
- > TODO: add documentation
-
+> TODO: add documentation
 
 ## Running
 
 You can start the services by running the following command in the directory where you cloned the repo:
+
 ```bash
 docker compose up -d
 ```
+
 The API will be running on `https://<your-ip>:<API_PORT>`.
 
-> *NOTE*: The `-d` flag runs the services in the background, so you can safely exit the session and the services will continue to run.
+> _NOTE_: The `-d` flag runs the services in the background, so you can safely exit the session and the services will continue to run. The `--build` flag ensures any changes to the code are reflected in the containers.
 
 You can stop the services with:
+
 ```bash
 docker compose down
 ```
 
 You can view the logs with:
+
 ```bash
 docker compose logs -f
 ```
+
 > You can dump them with `docker compose logs > some_file.txt`
 
 To view the logs for just a specific service component - for example the mining enginge - use:
+
 ```bash
 docker logs -f oapen-suggestion-service-oapen-engine-1
+```
+
+> _NOTE_: `oapen-suggestion-service-oapen-engine-1` is the name of the docker container running the service component.
+
+If you make local changes to the source code, you should re-build the images before running with:
+
+```bash
+docker compose build
+```
+
+or by adding the `--build` flag when running:
+
+```bash
+docker compose up -d --build
 ```
 
 ## Endpoints
@@ -216,72 +232,69 @@ You can find the code for the web demo in `web/`.
 Configuration info for the web demo is in [`web/README.md`](web/README.md).
 
 **Base dependencies**:
-* NodeJS 14.x+
-* NPM package manager
+
+- NodeJS 14.x+
+- NPM package manager
 
 **Automatically-installed dependencies**:
-* `next` -- Framework for production-driven web apps
-    * Maintained by [Vercel](https://vercel.com) and the open source community
-* `react` -- Frontend design framework
-    * Maintained by [Meta](https://reactjs.org). 
-    * Largest frontend web UI library.
-    * (Alternative considered: Angular -- however, was recently deprecated by Google)
-* `pg` -- basic PostgreSQL driver
-    * Maintained [on npm](https://www.npmjs.com/package/pg)
-* `typescript` -- Types for JavaScript
-    * Maintained by [Microsoft](https://www.typescriptlang.org/) and the open source community.
+
+- `next` -- Framework for production-driven web apps
+  - Maintained by [Vercel](https://vercel.com) and the open source community
+- `react` -- Frontend design framework
+  - Maintained by [Meta](https://reactjs.org).
+  - Largest frontend web UI library.
+  - (Alternative considered: Angular -- however, was recently deprecated by Google)
+- `pg` -- basic PostgreSQL driver
+  - Maintained [on npm](https://www.npmjs.com/package/pg)
+- `typescript` -- Types for JavaScript
+  - Maintained by [Microsoft](https://www.typescriptlang.org/) and the open source community.
 
 ## Updates
+
 > TODO: add documentation
 
 ## Local Installation (No Server)
 
 1. **Install Docker**
 
-    This project uses Docker. Instructions for installing Docker [here](https://docs.docker.com/get-docker/). Note that if you do not install Docker with Docker Desktop (which is recommended) you will have to install Docker Compose separately Instructions for that [here](https://docs.docker.com/compose/install/#scenario-two-install-the-compose-plugin).
+   This project uses Docker. Instructions for installing Docker [here](https://docs.docker.com/get-docker/). Note that if you do not install Docker with Docker Desktop (which is recommended) you will have to install Docker Compose separately Instructions for that [here](https://docs.docker.com/compose/install/#scenario-two-install-the-compose-plugin).
 
 2. **Install PostgreSQL**
-    
-    You can find instructions for installing PostgreSQL on your machine [here](https://www.postgresql.org/download/).
 
-    Or you can create a PostgreSQL server with Docker:
-    
-    ```bash
-    docker run -d --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=postgrespw postgres
-    ```
-    
-    > The username and database name will both be `postgres` and the password will be `postgrespw`. You can connect via the hostname `host.docker.internal` over port `5432`.
+   You can find instructions for installing PostgreSQL on your machine [here](https://www.postgresql.org/download/).
+
+   Or you can create a PostgreSQL server with Docker:
+
+   ```bash
+   docker run -d --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=postgrespw postgres
+   ```
+
+   > The username and database name will both be `postgres` and the password will be `postgrespw`. You can connect via the hostname `host.docker.internal` over port `5432`.
 
 3. **Clone and configure the project**
 
-    - Clone the repo and go into its directory:
+   - Clone the repo and go into its directory:
 
-        ```bash
-        git clone https://github.com/EbookFoundation/oapen-suggestion-service.git
-        cd oapen-suggestion-service
-        ```
-    - Copy the `.env.template` file to `.env`:
-        ```bash
-        cp .env.template .env
-        ```
+     ```bash
+     git clone https://github.com/EbookFoundation/oapen-suggestion-service.git
+     cd oapen-suggestion-service
+     ```
 
-    - Using a text editor like `vim` or `nano` configure all of the options in `.env`:
-        ```properties
-        API_PORT=<Port to serve API on>
-        POSTGRES_HOST=<Hostname of postgres server>
-        POSTGRES_PORT=<Port postgres is running on>
-        POSTGRES_DB_NAME=<Name of the postgres database>
-        POSTGRES_USERNAME=<Username of the postgres user>
-        POSTGRES_PASSWORD=<Password of the postgres user>
-        POSTGRES_SSLMODE=<'allow' for a local installation>
-        ```
-    - Open the `docker-compose.yml` file and find the line:
-        ```dockerfile
-        - RUN_CLEAN=1
-        ```
-        This is set to `1` by default, which causes the database to be ***COMPLETELY*** deleted and the types recreated each time the server restarts. It is important to have this set to `1` only on the _first run of the application_, or after making changes that affect the structure of the database. As soon as you run the application with the following command, you should change the line to:
-        ```dockerfile
-        - RUN_CLEAN=0
-        ```
-        To prevent this behavior.
+   - Copy the `.env.template` file to `.env`:
+
+     ```bash
+     cp .env.template .env
+     ```
+
+   - Using a text editor like `vim` or `nano` configure all of the options in `.env`:
+     ```properties
+     API_PORT=<Port to serve API on>
+     POSTGRES_HOST=<Hostname of postgres server>
+     POSTGRES_PORT=<Port postgres is running on>
+     POSTGRES_DB_NAME=<Name of the postgres database>
+     POSTGRES_USERNAME=<Username of the postgres user>
+     POSTGRES_PASSWORD=<Password of the postgres user>
+     POSTGRES_SSLMODE=<'allow' for a local installation>
+     ```
+
 4. See [Running](#running)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     env_file:
       - .env
     environment:
-      - RUN_CLEAN=0
       - COLLECTION_IMPORT_LIMIT=0   # Set to 0 for full harvest
       - REFRESH_PERIOD=86400        # daily
       - HARVEST_PERIOD=604800       # weekly

--- a/oapen-engine/README.md
+++ b/oapen-engine/README.md
@@ -1,21 +1,41 @@
-# OAPEN Suggestion Service
-## Getting Started
-### Running the application
-Ensure that you have followed the setup instructions in the top level README, then run:
+# Suggestion Engine
+## Updating/migrating the database
+When you make database changes, or add new stopwords, you'll want to completely re-run the harvesting and suggestion creation for the database. Though this happens weekly by default, you have some more immediate options:
+
+To erase & recreate the database _NOW_, you can run:
+```bash
+docker exec -it oapen-suggestion-service-oapen-engine-1 "/home/appuser/scripts/clean.sh"
 ```
-docker-compose up --build
+> *WARNING*: You will lose ALL database data! Reruns are resource-intensive and lengthy, be sure before running this. This _could_ cause unexpected errors if the running service is active, in which case you will need to restart with `docker compose up`.
+
+To erase & recreate the database _on the next run_, you can run:
+```bash
+docker exec -it oapen-suggestion-service-oapen-engine-1 "/home/appuser/scripts/mark-for-cleaning.sh"
 ```
-### Cleaning the database manually
+> *WARNING*: You will lose ALL database data! Reruns are resource-intensive and lengthy, be sure before running this. This is safer than the last command and should not cause any breakage, even if the database is being used by the service actively.
+
+To cancel the operation above, so the database is _not_ erased on the next run, you can run:
+```bash
+docker exec -it oapen-suggestion-service-oapen-engine-1 "/home/appuser/scripts/do-not-clean.sh"
 ```
-./scripts/clean.sh
+
+### How it works
+Those last two operations work by creating/deleting a table called `migrate` in the `oapen_suggestions` schema in the database. When the table exists, the daemon checks for the existence of the table when starting up, and drops & recreates the schema, tables, and types if it exists. It then deletes the table. When the table does not exist, the database is left as-is. You can also manually create the `migrate` table via an SQL query in any database admin tool, and the database will be re-created on the next run.
+
+## Running the engine alone
+Ensure that you have followed the [setup instructions](../README.md#installation-server), then run:
 ```
-### Refreshing items + suggestions manually
+docker-compose up -d --build
+```
+
+## Refreshing items + suggestions manually
 ```
 ./scripts/refresh.sh
 ```
+
 ## How to remove/filter out bad ngrams
-Members of EbookFoundation can create a pull request to edit the stopwords used to filter out bad trigrams:
+People with access to the repository can create a pull request to edit the stopwords used to filter out bad trigrams:
 ```
 oapen-engine/src/model/stopwords_*.txt
 ```
-This also can be done to remove a malformed trigram already in the database (during the next run)
+Changes in stopwords will not reflected until the next harvest, which occurs weekly by default.

--- a/oapen-engine/scripts/clean.sh
+++ b/oapen-engine/scripts/clean.sh
@@ -1,1 +1,3 @@
-python src/tasks/clean.py
+#!/bin/sh
+
+python src/tasks/clean.py "now"

--- a/oapen-engine/scripts/do-not-clean.sh
+++ b/oapen-engine/scripts/do-not-clean.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python src/tasks/clean.py "false"

--- a/oapen-engine/scripts/mark-for-cleaning.sh
+++ b/oapen-engine/scripts/mark-for-cleaning.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python src/tasks/clean.py "true"

--- a/oapen-engine/src/data/oapen_db.py
+++ b/oapen-engine/src/data/oapen_db.py
@@ -68,7 +68,7 @@ class OapenDB:
         cursor.close()
         return args
 
-    def table_exists(self, table):
+    def table_exists(self, table_name):
         cursor = self.connection.cursor()
         query = """
                 SELECT EXISTS (
@@ -77,10 +77,29 @@ class OapenDB:
                 """
 
         try:
-            cursor.execute(query, (table,))
+            cursor.execute(query, (table_name,))
             res = cursor.fetchone()[0]
 
-            return res is not None
+            return bool(res)
+        except (Exception, psycopg2.Error) as error:
+            logger.error(error)
+            return False
+        finally:
+            cursor.close()
+
+    def type_exists(self, type_name):
+        cursor = self.connection.cursor()
+        query = """
+            SELECT EXISTS (
+                SELECT 1 FROM pg_type WHERE typname = %s
+            )
+            """
+
+        try:
+            cursor.execute(query, (type_name,))
+            res = cursor.fetchone()[0]
+
+            return bool(res)
         except (Exception, psycopg2.Error) as error:
             logger.error(error)
             return False

--- a/oapen-engine/src/tasks/clean.py
+++ b/oapen-engine/src/tasks/clean.py
@@ -66,7 +66,7 @@ def create_schema(connection) -> None:
 
 
 def drop_schema(connection) -> None:
-    logger.warn("WARNING: DROPPING DATABASE!")
+    logger.warning("WARNING: DROPPING DATABASE!")
     cursor = connection.cursor()
     cursor.execute(
         """
@@ -74,6 +74,7 @@ def drop_schema(connection) -> None:
         DROP TABLE IF EXISTS oapen_suggestions.suggestions CASCADE;
         DROP TABLE IF EXISTS oapen_suggestions.ngrams CASCADE;
         DROP TABLE IF EXISTS oapen_suggestions.endpoints CASCADE;
+        DROP TABLE IF EXISTS oapen_suggestions.migrate;
         DROP TYPE IF EXISTS oapen_suggestions.ngram CASCADE;
         """
     )
@@ -123,12 +124,54 @@ def seed_endpoints(connection):
     endpoints = get_endpoints()
     db.add_urls(endpoints)
 
+def mark_for_cleaning(connection):
+    cursor = connection.cursor()
+    cursor.execute(
+        """
+        CREATE SCHEMA IF NOT EXISTS oapen_suggestions;
+        CREATE TABLE IF NOT EXISTS oapen_suggestions.migrate (migrate boolean);
+        """
+    )
+    cursor.close()
+
+def mark_no_clean(connection):
+    cursor = connection.cursor()
+    cursor.execute(
+        """
+        CREATE SCHEMA IF NOT EXISTS oapen_suggestions;
+        DROP TABLE IF EXISTS oapen_suggestions.migrate;
+        """
+    )
+    cursor.close()
 
 def run():
     connection = get_connection()
 
     drop_schema(connection)
     create_schema(connection)
+    mark_no_clean(connection)
     seed_endpoints(connection)
 
     connection.close()
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2 and sys.argv[1] in ["now", "true", "false"]:
+        connection = get_connection()
+        if sys.argv[1] == "now":
+            run()
+        elif sys.argv[1] == "true":
+            mark_for_cleaning(connection)
+            logger.warning("WARNING: The database will be ERASED on the next run.")
+        elif sys.argv[1] == "false":
+            mark_no_clean(connection)
+            logger.info("The database will not be cleaned on the next run.")
+        connection.close()
+    else:
+        logger.error("""
+            usage: clean.py [true or false]
+            options:
+            now         Clean the database now. Drops ALL DATA in the database!
+            true        Clean the database on the next run of the service. Drops ALL DATA in the database!
+            false       Do not clean the database on the next run. Leaves the database as it is.
+            """
+        )

--- a/oapen-engine/src/tasks/daemon.py
+++ b/oapen-engine/src/tasks/daemon.py
@@ -45,10 +45,11 @@ def main():
 
     logger.info("Daemon up")
 
-    if int(os.environ["RUN_CLEAN"]) == 1 or (
-        not db.table_exists("suggestions")
-        or not db.table_exists("ngrams")
-        or not db.table_exists("endpoints")
+    if db.table_exists("migrate") or not (
+        db.table_exists("suggestions")
+        and db.table_exists("ngrams")
+        and db.table_exists("endpoints")
+        and db.type_exists("ngram")
     ):
         run_clean()
 


### PR DESCRIPTION
Removed RUN_CLEAN so database is manually built on first run, and not purged on consecutive runs unless explicitly directed to.
Added scripts for manually rebuilding database, instructions are in `oapen-enginge/README.md`