### PR TITLE
try reducing the number of ingest workers to 1

### DIFF
--- a/oapen-engine/src/tasks/config.py
+++ b/oapen-engine/src/tasks/config.py
@@ -1,7 +1,7 @@
 ITEMS_PER_IMPORT_THREAD = 25
 
 # Max thread count for data ingest
-IO_MAX_WORKERS = 5
+IO_MAX_WORKERS = 1
 
 # Delay for submitting new API call thread
 HARVEST_THREAD_SPAWN_DELAY = 5


### PR DESCRIPTION
I think we've been overloading the OAPEN API; in any case, we've loaded most of the items and we're now liimited by the slowness of the system at retrieving result pages past one thousand.